### PR TITLE
Restructure gammatone implementation using Eigen

### DIFF
--- a/src/include/equivalent_rectangular_bandwidth.h
+++ b/src/include/equivalent_rectangular_bandwidth.h
@@ -28,6 +28,23 @@ namespace Visqol {
  */
 struct ErbFiltersResult {
   /**
+  * An enumeration that assigns the ERB filters coefficient names to the corresponding
+  * column indices of the ErbFiltersResult::filterCoeffs matrix.
+  */
+  enum CoeffsMap {
+    A0 = 0,
+    A11 = 1,
+    A12 = 2,
+    A13 = 3,
+    A14 = 4,
+    A2 = 5,
+    B0 = 6,
+    B1 = 7,
+    B2 = 8,
+    Gain = 9
+  };
+
+  /**
    * The filter coefficients for the ERB filter.
    */
   std::vector<std::vector<double>> filterCoeffs;

--- a/src/include/gammatone_filterbank.h
+++ b/src/include/gammatone_filterbank.h
@@ -22,6 +22,8 @@
 
 #include "amatrix.h"
 
+#include "Eigen/Dense"
+
 namespace Visqol {
 
 /**
@@ -66,7 +68,7 @@ class GammatoneFilterBank {
    *
    * @return The filtered output.
    */
-  AMatrix<double> ApplyFilter(const std::valarray<double>& signal);
+  Eigen::MatrixXd ApplyFilter(const Eigen::MatrixXd &signal);
 
   /**
    * Set the equivalent rectangular bandwidth filter coefficients that are to
@@ -95,20 +97,21 @@ class GammatoneFilterBank {
    */
   double min_freq_;
 
-  std::valarray<std::valarray<double>> fltr_cond_1_;
-  std::valarray<std::valarray<double>> fltr_cond_2_;
-  std::valarray<std::valarray<double>> fltr_cond_3_;
-  std::valarray<std::valarray<double>> fltr_cond_4_;
-  std::valarray<double> fltr_coeff_A0_;
-  std::valarray<double> fltr_coeff_A11_;
-  std::valarray<double> fltr_coeff_A12_;
-  std::valarray<double> fltr_coeff_A13_;
-  std::valarray<double> fltr_coeff_A14_;
-  std::valarray<double> fltr_coeff_A2_;
-  std::valarray<double> fltr_coeff_B0_;
-  std::valarray<double> fltr_coeff_B1_;
-  std::valarray<double> fltr_coeff_B2_;
-  std::valarray<double> fltr_coeff_gain_;
+  Eigen::MatrixXd fltr_cond_1_;
+  Eigen::MatrixXd fltr_cond_2_;
+  Eigen::MatrixXd fltr_cond_3_;
+  Eigen::MatrixXd fltr_cond_4_;
+  Eigen::MatrixXd a1;
+  Eigen::MatrixXd a2;
+  Eigen::MatrixXd a3;
+  Eigen::MatrixXd a4;
+  Eigen::MatrixXd b;
+
+  /**
+   * This is dependent to the filters order. For a 2nd order filter
+   * we need 3 coeffs for numerator and denominator.
+   */
+   const int kFilterLength = 3;
 };
 }  // namespace Visqol
 

--- a/tests/gammatone_filterbank_test.cc
+++ b/tests/gammatone_filterbank_test.cc
@@ -25,13 +25,13 @@ const size_t kSampleRate = 48000;
 const size_t kNumBands = 32;
 const double kMinFreq = 50;
 
-// The contents of this input signal are random figures.
-const AMatrix<double> k10Samples{
-    std::valarray<double>{0.2, 0.4, 0.6, 0.8, 0.9, 0.1, 0.3, 0.5, 0.7, 0.9}};
-
 // Ensure that the output matrix from the signal filter has the correct
 // dimensions.
 TEST(ApplyFilterTest, basic_positive_flow) {
+  // The contents of this input signal are random figures.
+  Eigen::MatrixXd k10Samples (10, 1);
+  k10Samples << 0.2, 0.4, 0.6, 0.8, 0.9, 0.1, 0.3, 0.5, 0.7, 0.9;
+
   auto filter_bank = GammatoneFilterBank{kNumBands, kMinFreq};
   auto erb = EquivalentRectangularBandwidth::MakeFilters(
       kSampleRate, kNumBands, kMinFreq, kSampleRate / 2);
@@ -39,10 +39,10 @@ TEST(ApplyFilterTest, basic_positive_flow) {
   filter_coeffs = filter_coeffs.FlipUpDown();
   filter_bank.SetFilterCoefficients(filter_coeffs);
   auto filtered_signal =
-      filter_bank.ApplyFilter(k10Samples.GetColumn(0).ToValArray());
+      filter_bank.ApplyFilter(k10Samples);
 
-  ASSERT_EQ(k10Samples.NumElements(), filtered_signal.NumCols());
-  ASSERT_EQ(kNumBands, filtered_signal.NumRows());
+  ASSERT_EQ(k10Samples.size(), filtered_signal.cols());
+  ASSERT_EQ(kNumBands, filtered_signal.rows());
 }
 
 }  // namespace


### PR DESCRIPTION
This PR helps to easily compare the `eigen-replace-arma` and `gammatone-optimization` branches, showing the added changes that optimize the gammatone implementation using Eigen matrix operations.